### PR TITLE
feat: add loader component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14024,6 +14024,14 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
+    "react-loader-spinner": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-2.1.0.tgz",
+      "integrity": "sha1-LsVRgiiQvVNygQFZowtepJxwD1Y=",
+      "requires": {
+        "babel-runtime": "^6.6.1"
+      }
+    },
     "react-modal": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^16.4.2",
     "react-helmet": "^5.2.0",
     "react-intl": "^2.4.0",
+    "react-loader-spinner": "^2.1.0",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.5",
     "react-test-renderer": "^16.4.2",

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -27,7 +27,6 @@ export default {
       case 'FILES_ADD_STARTED':
         return {
           ...state,
-          loading: true,
           files: {
             ...state.files,
             ...action.payload.file
@@ -37,7 +36,6 @@ export default {
       case 'FILES_ADD_PROGRESS':
         return {
           ...state,
-          loading: true,
           files: {
             ...state.files,
             [action.payload.id]: {
@@ -62,7 +60,6 @@ export default {
             ...state.shareLink,
             outdated: true
           },
-          loading: false,
           error: null
         }
 
@@ -80,8 +77,7 @@ export default {
           shareLink: {
             ...state.shareLink,
             outdated: false
-          },
-          loading: false
+          }
         }
 
       case 'FILES_SHARE_LINK':
@@ -120,7 +116,7 @@ export default {
       case 'FILES_FETCH_GATEWAY_FAILED':
         return {
           ...state,
-          loading: true,
+          loading: false,
           files: {
             ...state.files,
             error: action.payload.error
@@ -139,6 +135,8 @@ export default {
   /* ============================================================
      Selectors
      ============================================================ */
+
+  selectIsLoading: state => state.files.loading,
 
   selectFiles: state => state.files.files,
 

--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
 // Components
+import Loader from '../loader/Loader'
 import AddFiles from '../add-files/AddFiles'
 import FileTree from '../file-tree/FileTree'
 import CopyLink from '../copy-link//CopyLink'
@@ -12,23 +13,29 @@ const Footnote = () => (
   </div>
 )
 
-const Box = ({ isDownload, files, shareLink }) => {
+const Box = ({ isDownload, files, shareLink, isLoading }) => {
   const boxClass = 'mb4 mb0-l pa4 w-100 w-third-l mw6 order-2-l br3 shadow-4 bg-white'
 
-  return (
-    isDownload
-      ? <div className={boxClass}>
-        <FileTree files={files} isDownload />
-        <DownloadFiles />
-        <Footnote />
-      </div>
-      : <div className={boxClass}>
-        <AddFiles />
-        <FileTree files={files} isDownload={isDownload} />
-        { shareLink && <CopyLink shareLink={shareLink} /> }
-        <Footnote />
-      </div>
+  const renderUpload = () => (
+    <div className={boxClass}>
+      <AddFiles />
+      { isLoading && <Loader /> }
+      <FileTree files={files} isDownload={isDownload} />
+      { shareLink && <CopyLink shareLink={shareLink} /> }
+      <Footnote />
+    </div>
   )
+
+  const renderDownload = () => (
+    <div className={boxClass}>
+      { isLoading && <Loader /> }
+      <FileTree files={files} isDownload />
+      <DownloadFiles />
+      <Footnote />
+    </div>
+  )
+
+  return isDownload ? renderDownload() : renderUpload()
 }
 
 export default Box

--- a/src/components/loader/Loader.css
+++ b/src/components/loader/Loader.css
@@ -1,0 +1,4 @@
+
+.Loader > div {
+  display: flex;
+}

--- a/src/components/loader/Loader.js
+++ b/src/components/loader/Loader.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import LoaderSpinner from 'react-loader-spinner'
+import './Loader.css'
+
+const Loader = ({
+  loader = 'Puff',
+  color = '#022e44',
+  size = 25,
+  text = 'Loading file list...'
+}) => (
+  <div className='Loader mv4 flex items-center'>
+    <LoaderSpinner type={loader} color={color} height={size} width={size} />
+    <span className='ml2 navy f6'>{text}</span>
+  </div>
+)
+
+export default Loader

--- a/src/pages/download/Download.js
+++ b/src/pages/download/Download.js
@@ -10,6 +10,7 @@ import Info from '../../components/info/Info'
 class Download extends React.Component {
   static propTypes = {
     routeInfo: PropTypes.object.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     files: PropTypes.object.isRequired,
     doFetchGatewayFileTree: PropTypes.func.isRequired
   }
@@ -21,7 +22,7 @@ class Download extends React.Component {
   }
 
   render () {
-    const { files } = this.props
+    const { files, isLoading } = this.props
 
     return (
       <div data-id='Download'>
@@ -30,7 +31,7 @@ class Download extends React.Component {
         </Helmet>
 
         <div className='flex flex-column flex-row-l justify-center items-center'>
-          <Box files={files} isDownload />
+          <Box files={files} isDownload isLoading={isLoading} />
           <Info />
         </div>
       </div>
@@ -40,6 +41,7 @@ class Download extends React.Component {
 
 export default connect(
   'selectRouteInfo',
+  'selectIsLoading',
   'selectFiles',
   'doFetchGatewayFileTree',
   Download

--- a/src/pages/upload/Upload.js
+++ b/src/pages/upload/Upload.js
@@ -15,6 +15,7 @@ class Upload extends React.Component {
     currentPage: PropTypes.string.isRequired,
     routeInfo: PropTypes.object.isRequired,
     ipfsReady: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     files: PropTypes.object,
     shareLink: PropTypes.string,
     doFetchFileTree: PropTypes.func.isRequired
@@ -29,7 +30,7 @@ class Upload extends React.Component {
   }
 
   render () {
-    const { files, shareLink } = this.props
+    const { files, shareLink, isLoading } = this.props
 
     return (
       <div data-id='Upload'>
@@ -38,7 +39,7 @@ class Upload extends React.Component {
         </Helmet>
 
         <div className='flex flex-column flex-row-l justify-center items-center'>
-          <Box files={files} shareLink={shareLink} />
+          <Box files={files} shareLink={shareLink} isLoading={isLoading} />
           <Info />
         </div>
       </div>
@@ -49,6 +50,7 @@ class Upload extends React.Component {
 export default connect(
   'selectCurrentPage',
   'selectRouteInfo',
+  'selectIsLoading',
   'selectIpfsReady',
   'selectFiles',
   'selectShareLink',


### PR DESCRIPTION
Adds a loader when fetching the file tree, both for the download and upload pages. This is useful specially when fetching from the gateway because usually it's slow.

Preview:

<img width="483" alt="loader" src="https://user-images.githubusercontent.com/33324750/44924324-dd79e480-ad42-11e8-90ea-e657d6d8f18f.png">
