### PR TITLE
fix: build dir

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,6 +1,6 @@
 website([
   website: 'share.ipfs.io',
-  build_directory: 'public/',
+  build_directory: 'build/',
   disable_publish: false,
   record: [
     'master': '_dnslink',


### PR DESCRIPTION
When creating this file I copy-pasted it from another project that used [Gatsby](https://www.gatsbyjs.org/), that builds the project to `public/`. As I'm using [create-react-app](https://github.com/facebook/create-react-app/), it builds the project to the `build/` folder. This PR fixes that mistake 😇