### PR TITLE
refactor: fetch file tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6695,11 +6695,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6712,15 +6714,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6823,7 +6828,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6833,6 +6839,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6845,17 +6852,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6872,6 +6882,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6944,7 +6955,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6954,6 +6966,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7059,6 +7072,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,9 @@ export class App extends Component {
     route: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.element
-    ]).isRequired
+    ]).isRequired,
+    ipfsReady: PropTypes.bool.isRequired,
+    ipfsInitFailed: PropTypes.bool.isRequired
   }
 
   componentWillMount () {
@@ -25,14 +27,18 @@ export class App extends Component {
   }
 
   render () {
-    const Page = this.props.route
+    const { route: Page, ipfsReady, ipfsInitFailed } = this.props
+    // Only shows the page if IPFS is ready of if the initialization has failed.
+    // This way we can make sure we always use user's own node if available and
+    // the public gatway otherwise.
+    const ready = ipfsReady || ipfsInitFailed
 
     return (
       <div className='App sans-serif' onClick={navHelper(this.props.doUpdateUrl)}>
         <div className='flex flex-column min-vh-100'>
           <Header />
           <main className='flex-auto pa4'>
-            <Page />
+            { ready && <Page /> }
           </main>
           <Footer />
         </div>
@@ -43,6 +49,8 @@ export class App extends Component {
 
 export default connect(
   'selectRoute',
+  'selectIpfsReady',
+  'selectIpfsInitFailed',
   'doUpdateUrl',
   'doInitIpfs',
   App

--- a/src/App.js
+++ b/src/App.js
@@ -28,9 +28,9 @@ export class App extends Component {
 
   render () {
     const { route: Page, ipfsReady, ipfsInitFailed } = this.props
-    // Only shows the page if IPFS is ready of if the initialization has failed.
+    // Only shows the page if IPFS is ready or if the initialization has failed.
     // This way we can make sure we always use user's own node if available and
-    // the public gatway otherwise.
+    // the public gateway otherwise.
     const ready = ipfsReady || ipfsInitFailed
 
     return (

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -218,16 +218,16 @@ export default {
     }
   },
 
-  doFetchFileTree: (hash) => async ({ dispatch, getIpfs }) => {
-    const ipfs = getIpfs()
+  doFetchFileTree: (hash) => async ({ dispatch, store, getIpfs }) => {
     let ifpsFiles
     let files = {}
 
     dispatch({ type: 'FILES_FETCH_STARTED' })
 
     try {
-      // opportunistically determine whether to use the public gateway or the user's node.
-      if (ipfs) {
+      // determines whether to use the public gateway or the user's node.
+      if (store.selectIpfsReady()) {
+        const ipfs = getIpfs()
         ifpsFiles = await ipfs.ls(hash)
       } else {
         const url = `${ENDPOINTS.api}/v0/ls?arg=${hash}`

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -219,7 +219,7 @@ export default {
   },
 
   doFetchFileTree: (hash) => async ({ dispatch, store, getIpfs }) => {
-    let ifpsFiles
+    let ipfsFiles
     let files = {}
 
     dispatch({ type: 'FILES_FETCH_STARTED' })
@@ -228,15 +228,15 @@ export default {
       // determines whether to use the public gateway or the user's node.
       if (store.selectIpfsReady()) {
         const ipfs = getIpfs()
-        ifpsFiles = await ipfs.ls(hash)
+        ipfsFiles = await ipfs.ls(hash)
       } else {
         const url = `${ENDPOINTS.api}/v0/ls?arg=${hash}`
         const res = await window.fetch(url)
         const objs = await res.json()
-        ifpsFiles = objs.Objects[0].Links
+        ipfsFiles = objs.Objects[0].Links
       }
 
-      for (const file of ifpsFiles) {
+      for (const file of ipfsFiles) {
         const fileId = shortid.generate()
         const fileName = file.name || file.Name
         const fileSize = file.size || file.Size

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -91,14 +91,12 @@ export default {
         }
 
       case 'FILES_FETCH_STARTED':
-      case 'FILES_FETCH_GATEWAY_STARTED':
         return {
           ...state,
           loading: true
         }
 
       case 'FILES_FETCH_FINISHED':
-      case 'FILES_FETCH_GATEWAY_FINISHED':
         return {
           ...state,
           loading: false,
@@ -113,7 +111,6 @@ export default {
         }
 
       case 'FILES_FETCH_FAILED':
-      case 'FILES_FETCH_GATEWAY_FAILED':
         return {
           ...state,
           loading: false,
@@ -221,62 +218,43 @@ export default {
     }
   },
 
-  doFetchFileTree: (hash) => async ({ dispatch, store, getIpfs }) => {
+  doFetchFileTree: (hash) => async ({ dispatch, getIpfs }) => {
     const ipfs = getIpfs()
+    let ifpsFiles
+    let files = {}
 
     dispatch({ type: 'FILES_FETCH_STARTED' })
 
-    ipfs.ls(hash)
-      .then(ipfsFiles => {
-        const files = {}
+    try {
+      // opportunistically determine whether to use the public gateway or the user's node.
+      if (ipfs) {
+        ifpsFiles = await ipfs.ls(hash)
+      } else {
+        const url = `${ENDPOINTS.api}/v0/ls?arg=${hash}`
+        const res = await window.fetch(url)
+        const objs = await res.json()
+        ifpsFiles = objs.Objects[0].Links
+      }
 
-        for (const file of ipfsFiles) {
-          const fileId = shortid.generate()
-          const fileName = file.name
-          const fileSize = file.size
-          const fileHash = file.hash
+      for (const file of ifpsFiles) {
+        const fileId = shortid.generate()
+        const fileName = file.name || file.Name
+        const fileSize = file.size || file.Size
+        const fileHash = file.hash || file.Hash
 
-          files[fileId] = {
-            name: fileName,
-            size: fileSize,
-            hash: fileHash,
-            progress: 100,
-            pending: false
-          }
+        files[fileId] = {
+          name: fileName,
+          size: fileSize,
+          hash: fileHash,
+          progress: 100,
+          pending: false
         }
-        dispatch({ type: 'FILES_FETCH_FINISHED', payload: { files: files } })
-      })
-      .catch(err => dispatch({ type: 'FILES_FETCH_FAILED', payload: { error: err.message } }))
-  },
+      }
 
-  doFetchGatewayFileTree: (hash) => async ({ dispatch, store }) => {
-    const url = `${ENDPOINTS.api}/v0/ls?arg=${hash}`
-
-    dispatch({ type: 'FILES_FETCH_GATEWAY_STARTED' })
-
-    window.fetch(url)
-      .then(res => res.json())
-      .then(res => {
-        const ipfsFiles = res.Objects[0].Links
-        const files = {}
-
-        for (const file of ipfsFiles) {
-          const fileId = shortid.generate()
-          const fileName = file.Name
-          const fileSize = file.Size
-          const fileHash = file.Hash
-
-          files[fileId] = {
-            name: fileName,
-            size: fileSize,
-            hash: fileHash,
-            progress: 100,
-            pending: false
-          }
-        }
-        dispatch({ type: 'FILES_FETCH_GATEWAY_FINISHED', payload: { files: files } })
-      })
-      .catch(err => dispatch({ type: 'FILES_FETCH_GATEWAY_FAILED', payload: { error: err.message } }))
+      dispatch({ type: 'FILES_FETCH_FINISHED', payload: { files: files } })
+    } catch (err) {
+      dispatch({ type: 'FILES_FETCH_FAILED', payload: { error: err.message } })
+    }
   },
 
   doGetDownloadLink: (files) => async ({ dispatch, store, getIpfs }) => {

--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -1,4 +1,3 @@
-
 export default {
   gateway: 'https://ipfs.io/ipfs',
   api: 'https://ipfs.io/api'

--- a/src/constants/pages.js
+++ b/src/constants/pages.js
@@ -1,4 +1,3 @@
-
 export default {
   upload: 'upload',
   download: 'download'

--- a/src/pages/download/Download.js
+++ b/src/pages/download/Download.js
@@ -12,13 +12,13 @@ class Download extends React.Component {
     routeInfo: PropTypes.object.isRequired,
     isLoading: PropTypes.bool.isRequired,
     files: PropTypes.object.isRequired,
-    doFetchGatewayFileTree: PropTypes.func.isRequired
+    doFetchFileTree: PropTypes.func.isRequired
   }
 
   componentDidMount () {
-    const { routeInfo: { params }, doFetchGatewayFileTree } = this.props
+    const { routeInfo: { params }, doFetchFileTree } = this.props
 
-    doFetchGatewayFileTree(params.hash)
+    doFetchFileTree(params.hash)
   }
 
   render () {
@@ -43,6 +43,6 @@ export default connect(
   'selectRouteInfo',
   'selectIsLoading',
   'selectFiles',
-  'doFetchGatewayFileTree',
+  'doFetchFileTree',
   Download
 )

--- a/src/pages/upload/Upload.js
+++ b/src/pages/upload/Upload.js
@@ -14,17 +14,16 @@ class Upload extends React.Component {
   static propTypes = {
     currentPage: PropTypes.string.isRequired,
     routeInfo: PropTypes.object.isRequired,
-    ipfsReady: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
     files: PropTypes.object,
     shareLink: PropTypes.string,
     doFetchFileTree: PropTypes.func.isRequired
   }
 
-  componentDidUpdate (prevProps) {
-    const { currentPage, routeInfo: { params }, ipfsReady, doFetchFileTree } = this.props
+  componentDidMount () {
+    const { currentPage, routeInfo: { params }, doFetchFileTree } = this.props
 
-    if (currentPage === PAGES.upload && params.hash && !prevProps.ipfsReady && ipfsReady) {
+    if (currentPage === PAGES.upload && params.hash) {
       doFetchFileTree(params.hash)
     }
   }
@@ -51,7 +50,6 @@ export default connect(
   'selectCurrentPage',
   'selectRouteInfo',
   'selectIsLoading',
-  'selectIpfsReady',
   'selectFiles',
   'selectShareLink',
   'doFetchFileTree',


### PR DESCRIPTION
This is a little improvement to reduce the amount of copied code. This way `doFetchFileTree` opportunistically determines whether to user's IPFS Daemon or the Public Gateway. It can still be improved a little.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>