### PR TITLE
fix: limit concurrent calls to ipfs.files.add

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ipfs-css": "^0.8.0",
     "ipfs-redux-bundle": "^2.0.0",
     "milliseconds": "^1.0.3",
+    "p-queue": "3.0.0",
     "prop-types": "^15.6.2",
     "pull-file-reader": "^1.0.2",
     "react": "^16.4.2",


### PR DESCRIPTION
This aim to improve UX by providing more intuitive progress
and solves performance issues when uploading multiple big files
to remote HTTP API.

Max of 2-3 concurrent uploads should  be a safe value.

cc @fsdiogo  check if this helped with issues you were having 