### PR TITLE
docs: remove CORS Credentials header

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Or do it manually:
 ```sh
 > ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://localhost:3000", "https://share.ipfs.io"]'
 > ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
 ```
 
 To reset the config to its default state run:

--- a/cors-config.sh
+++ b/cors-config.sh
@@ -7,7 +7,6 @@ set -e
 
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[$ALLOW_ORIGINS]"
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
 
 echo "IPFS API CORS headers configured for $ALLOW_ORIGINS"
 echo "Please restart your IPFS daemon"

--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -52,7 +52,6 @@ export const RawBoxNotAvailable = ({ t }) => (
     <div className='pa3 bg-black-80 bt bw4 br2 gray-muted f7 nowrap overflow-x-scroll'>
       <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["{ window.location.origin }", "https://share.ipfs.io"]'</code>
       <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'</code>
-      <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'</code>
     </div>
     <p className='mv3 navy f6 lh-copy'>{t('box.runDaemon')}</p>
     <div className='pa3 bg-black-80 bt bw4 br2 gray-muted f7 nowrap overflow-x-scroll'>


### PR DESCRIPTION
AFAIK Share App does not need this header.

See also:

- Potential problem with  `Access-Control-Allow-Credentials`: https://github.com/ipfs/go-ipfs/issues/5745
- HTTP Headers Cleanup: https://github.com/ipfs/in-web-browsers/issues/132
