### PR TITLE
fix: filename overflow

### DIFF
--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -112,7 +112,7 @@ export class File extends React.Component {
       <div className='mv2 flex items-center'>
         <a
           title={t('box.viewOnGateway')}
-          className='flex items-center link'
+          className='flex items-center link truncate'
           style={{ outline: 'none' }}
           href={`${ENDPOINTS.gateway}/${hash}`}
           target='_blank'
@@ -121,7 +121,7 @@ export class File extends React.Component {
           <span className={fileNameClass}>{name}</span>
           <span className={fileSizeClass}>{size && `(~${size})`}</span>
         </a>
-        <span className='ml-auto'>{ this.renderFileStatus() }</span>
+        <span className='ml-auto flex items-center'>{ this.renderFileStatus() }</span>
       </div>
     )
   }


### PR DESCRIPTION
<img width="698" alt="gh" src="https://user-images.githubusercontent.com/33324750/50101039-ac51f100-0219-11e9-8c02-94b81f000988.png">

Fixes https://github.com/ipfs-shipyard/ipfs-share-files/issues/67.