### PR TITLE
fix: automated deploy to IPFS with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,52 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:12.16.1
+    steps:
+      - checkout
+      - run:
+          command: npm ci
+      - run:
+          command: npm run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build
+
+  deploy:
+    docker:
+      - image: olizilla/ipfs-dns-deploy:latest
+        environment:
+          PROD_DOMAIN: share.ipfs.io
+          DEV_DOMAIN: dev.share.ipfs.io
+          BUILD_DIR: build
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Deploy website to IPFS
+          command: |
+            pin_name="ipfs-share-files build $CIRCLE_BUILD_NUMBER"
+
+            hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
+
+            echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
+
+            # Update DNSlink for prod or dev domain
+            if [ "$CIRCLE_BRANCH" == "production" ] ; then
+              dnslink-dnsimple -d $PROD_DOMAIN -r _dnslink -l /ipfs/$hash
+            fi
+            if [ "$CIRCLE_BRANCH" == "master" ] ; then
+              dnslink-dnsimple -d $DEV_DOMAIN -r _dnslink -l /ipfs/$hash
+            fi
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build
+      - deploy:
+          context: ipfs-dns-deploy
+          requires:
+            - build

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To build the app for production to the `build` folder:
 
 ### Deploy
 
-We use [Jenkins](https://jenkins.io/) for automatic deployments. When a branch gets merged to `master`, it's deployed to [share.ipfs.io](https://share.ipfs.io). When merged to `develop`, it goes to [dev.share.ipfs.io](https://dev.share.ipfs.io).
+We use CI for automatic deployments. When a branch gets merged to `master`, it's deployed to [dev.share.ipfs.io](https://dev.share.ipfs.io). When merged to `production`, it goes to [share.ipfs.io](https://share.ipfs.io).
 
 ## Translations
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,9 +1,0 @@
-website([
-  website: 'share.ipfs.io',
-  build_directory: 'build/',
-  disable_publish: false,
-  record: [
-    'master': '_dnslink',
-    'develop': '_dnslink.dev',
-  ]
-])

--- a/cors-config.sh
+++ b/cors-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 ALLOW_ORIGINS='"http://localhost:3000", "https://share.ipfs.io"'
 


### PR DESCRIPTION
This PR removes Jenkins config and adds CircleCI one.

This flips the deployment model:
- "master" branch is published to https://dev.share.ipfs.io
- "production" branch (can be created in the future) will be published to https://share.ipfs.io

cc #75 