### PR TITLE
fix: tweak share button text

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -43,7 +43,7 @@
     "labelIndividual": "Share individual files",
     "labelAll": "Share all files",
     "footNote": "This link changes if you add more files, so be sure to share the latest version.",
-    "copy": "Copy",
+    "copy": "Share",
     "copied": "Copied!"
   },
   "loader": "Loading file list…",


### PR DESCRIPTION
Per side-channel conversation, this PR changes button text to "Share" from "Copy" to make it clearer the user isn't copying the actual file.

After clicked, buttons still display "Copied!" to make it clear that the interaction copied the share link to the clipboard.

cc @terichadbourne 

![Screen Shot 2021-02-03 at 12 07 28 p](https://user-images.githubusercontent.com/1507828/106796334-6da96b80-6618-11eb-8992-574ee3cb0419.png)
