### PR TITLE
feat: add view icon on download page

### DIFF
--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -365,7 +365,7 @@ const bundle = {
     }
   },
 
-  doGetFileURL: (filename, cid) => async ({ store }) => {
+  doGetFileURL: (filename, cid, opts = { download: true }) => async ({ store }) => {
     const url = ENDPOINTS.gateway
 
     if (!cid) {
@@ -375,7 +375,7 @@ const bundle = {
     }
 
     return {
-      url: `${url}/${cid.string}?download=true&filename=${encodeURIComponent(filename)}`,
+      url: `${url}/${cid.string}?${opts.download ? 'download=true&' : ''}filename=${encodeURIComponent(filename)}`,
       filename
     }
   },

--- a/src/components/file/File.js
+++ b/src/components/file/File.js
@@ -5,6 +5,7 @@ import { CircularProgressbar } from 'react-circular-progressbar'
 import classnames from 'classnames'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
+import viewFile from './utils/view'
 import downloadFile from './utils/download'
 import downloadArchive from './utils/archive'
 import ENDPOINTS from '../../constants/endpoints'
@@ -21,6 +22,7 @@ import 'react-circular-progressbar/dist/styles.css'
 import GlyphTick from '../../media/icons/GlyphTick'
 import GlyphCancel from '../../media/icons/GlyphCancel'
 import IconDownload from '../../media/icons/Download'
+import IconView from '../../media/icons/View'
 import GlyphAttention from '../../media/icons/GlyphAttention'
 
 export class File extends React.Component {
@@ -40,6 +42,12 @@ export class File extends React.Component {
 
   state = {
     progress: 100
+  }
+
+  handleViewClick = async () => {
+    const { cid, name, doGetFileURL } = this.props
+    const { url, filename } = await doGetFileURL(name, cid, { download: false })
+    viewFile(url, filename)
   }
 
   handleDownloadClick = async () => {
@@ -72,6 +80,13 @@ export class File extends React.Component {
     if (isDownload && progress === 100) {
       return <div className='flex items-center'>
         { this.renderWarningSign() }
+        <IconView
+          className='pointer o-80 glow'
+          width={glyphWidth + 5}
+          fill={fillColor}
+          style={{ marginRight: '-3px' }}
+          onClick={this.handleViewClick}
+          alt='View' />
         <IconDownload
           className='pointer o-80 glow'
           width={glyphWidth + 5}

--- a/src/components/file/utils/view.js
+++ b/src/components/file/utils/view.js
@@ -1,0 +1,9 @@
+const view = (url, fileName) => {
+  const link = document.createElement('a')
+
+  link.setAttribute('href', url)
+  link.setAttribute('target', '_blank')
+  link.click()
+}
+
+export default view

--- a/src/media/icons/View.js
+++ b/src/media/icons/View.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const ViewIcon = props => (
+  <svg viewBox='0 0 24 24' width='24' height='24' {...props}>
+    <path d='M0 0h24v24H0z' fill='none' /><path d='M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z'/>
+  </svg>
+)
+
+export default ViewIcon


### PR DESCRIPTION
Closes #105 

This PR adds :eye: icon on download page which opens a gateway preview of a file  (same link as behind filename):

>  ![2021-02-05--02-22-08](https://user-images.githubusercontent.com/157609/106977208-2dea9d00-675a-11eb-948d-f7500f74223b.png)


@jessicaschilling lmk if this icon should be also added to the upload page. 