### PR TITLE
feat: branded SVG QR code

### DIFF
--- a/src/components/copy-link/CopyLink.js
+++ b/src/components/copy-link/CopyLink.js
@@ -46,7 +46,21 @@ class CopyLink extends React.Component {
         <div className="overflow-hidden">
           <div className="flex flex-column items-center mb3 appear-from-below">
             <span className="f7 charcoal-muted lh-copy pb2">{t('copyLink.qrLabel')}</span>
-            <QRCode value={shareLink}/>
+            <QRCode
+              value={shareLink}
+              bgColor={'#ffffff'}
+              fgColor={'#022E44'}
+              level={'L'}
+              renderAs={'svg'}
+              imageSettings={{
+                src: 'favicon-32x32.png',
+                x: null,
+                y: null,
+                height: 32,
+                width: 32,
+                excavate: true
+              }}
+            />
           </div>
         </div>
       </div>

--- a/src/components/copy-link/CopyLink.js
+++ b/src/components/copy-link/CopyLink.js
@@ -50,7 +50,7 @@ class CopyLink extends React.Component {
               value={shareLink}
               bgColor={'#ffffff'}
               fgColor={'#022E44'}
-              level={'L'}
+              level={'M'}
               renderAs={'svg'}
               imageSettings={{
                 src: 'favicon-32x32.png',


### PR DESCRIPTION
This PR tweaks the way QR code is generated and replaces `<canvas>` with `<svg>` which looks sharper (at least on my machine)

It also adds a bit of branding, so it looks more  native to the app   (works due to error-correction  built into QR codes)
(ok to revert this change – up for your consideration :see_no_evil: )

QR code playground: https://zpao.github.io/qrcode.react/
URL of the icon:  https://share.ipfs.io/favicon-32x32.png


| Before | After |
| ---- | ---- |
| ![Screenshot_2021-02-05 IPFS Share Share Files](https://user-images.githubusercontent.com/157609/107052623-2f55ad00-67ce-11eb-8451-afbd5ad26921.png) | ![Screenshot_2021-02-05 IPFS Share Share Files(1)](https://user-images.githubusercontent.com/157609/107052653-35e42480-67ce-11eb-98e3-776939334154.png) |

(click to compare 1:1) 