### PR TITLE
fix: simulated download progress doesn't trigger until files are downloaded

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -73,7 +73,9 @@
     "copied": "Copied!",
     "qrLabel": "Or scan to share all files"
   },
-  "loader": "Loading file list…",
+  "loader": {
+    "fileList": "Loading file list…"
+  },
   "downloadFiles": {
     "download": "Download",
     "downloadAll": "Download all",

--- a/src/components/box/box.tsx
+++ b/src/components/box/box.tsx
@@ -9,7 +9,6 @@ import { useDownloadInfo } from '../../providers/download-provider.jsx'
 import { AddFiles } from '../add-files/add-files.jsx'
 import { DownloadFiles } from '../download-files/download-files.jsx'
 import { FileTree } from '../file-tree/file-tree.jsx'
-import Loader from '../loader/loader.jsx'
 import { ShareAllFiles } from '../share-all-files/share-all-files.jsx'
 
 export const Box = forwardRef<HTMLDivElement, { children: any, className?: string }>((props, ref) => {
@@ -40,7 +39,6 @@ export const BoxDownload = (): React.JSX.Element => {
 
   return (
     <Box>
-      { isLoading && <Loader /> }
       <FileTree isDownload />
       <DownloadFiles isLoading={isLoading} />
     </Box>
@@ -72,13 +70,11 @@ export const BoxAdd = (): React.JSX.Element => {
 
   return <Box ref={drop} className={isOver ? '' : 'bg-gray-muted'} >
     <AddFiles doAddFiles={doAddFiles} />
-    {/* { isLoading && <Loader /> } */}
     <FileTree />
     <ShareAllFiles />
   </Box>
 }
 
-// TODO this text is all outdated
 export const BoxNotAvailable: React.FC<{ error: Error }> = ({ error }) => {
   const { t } = useTranslation('translation')
   return (

--- a/src/components/file-tree/file-tree.tsx
+++ b/src/components/file-tree/file-tree.tsx
@@ -2,11 +2,16 @@ import React from 'react'
 import { useTranslation, Trans } from 'react-i18next'
 import { useFiles } from '../../hooks/use-files.js'
 import { File } from '../file/file.jsx'
+import Loader from '../loader/loader.jsx'
 
 export const FileTree = ({ isDownload }: { isDownload?: boolean }): React.ReactNode => {
   const { t } = useTranslation()
   const { files } = useFiles()
   const filesMap = Object.entries(files)
+
+  if (isDownload === true && filesMap.length === 0) {
+    return <Loader text={t('loader.fileList')} />
+  }
 
   return (
   <div className=''>

--- a/src/components/loader/loader.tsx
+++ b/src/components/loader/loader.tsx
@@ -14,10 +14,15 @@ export interface LoaderProps {
 const Loader = ({
   // loader = 'Puff',
   color = '#022e44',
-  size = 25
+  size = 25,
+  text = ''
 }: LoaderProps): React.JSX.Element => {
   const { t } = useTranslation('translation')
-  const text = t('loader')
+
+  if (text === '') {
+    text = t('loader.fileList')
+  }
+
   return (
     <div className='Loader mv2 flex items-center'>
       <Puff color={color} height={size} width={size} />


### PR DESCRIPTION
This PR also overhauls the file-provider to be more resilient to mounting and unmounting.

Also fixes a bug with upload/download operations where filesToPublish would mark ALL files as published when the first *starts* to publish