### PR TITLE
chore: update ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
-name: Build and Deploy
+name: Build and Test
 
-# Run this workflow on push events to specific branches
 on:
   push:
     branches:
       - main
-      - production
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   # Build job
@@ -26,39 +27,5 @@ jobs:
       - name: Build the project
         run: npm run build
 
-      - name: Persist build output
-        id: build_output
-        run: |
-          echo "::set-output name=build_dir::build"
-
-  # Deploy job
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: ipfs-dns-deploy
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v2
-
-      - name: Pull deployment image
-        run: docker pull olizilla/ipfs-dns-deploy:latest
-
-      - name: Deploy website to IPFS
-        run: |
-          pin_name="ipfs-share-files build ${{ github.run_number }}"
-
-          # Pin the build directory to IPFS
-          hash=$(docker run --rm -e BUILD_DIR=${{ steps.build_output.outputs.build_dir }} olizilla/ipfs-dns-deploy:latest pin-to-cluster.sh "$pin_name" /github/workspace/build)
-
-          echo "Website added to IPFS: https://dweb.link/ipfs/$hash"
-
-          # Update DNSlink for production or dev domain
-          if [ "${{ github.ref }}" == "refs/heads/production" ]; then
-            docker run --rm olizilla/ipfs-dns-deploy:latest dnslink-dnsimple -d share.ipfs.io -r _dnslink -l /ipfs/$hash
-          elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            docker run --rm olizilla/ipfs-dns-deploy:latest dnslink-dnsimple -d dev.share.ipfs.io -r _dnslink -l /ipfs/$hash
-          fi
+      - name: Test the project
+        run: npm run test


### PR DESCRIPTION
We deploy to fleek on every change to master, no need to use the custom docker/dns/ipfs/publish thing.

Also, run CI on PRs and run the test suite.