### PR TITLE
feat: add human friendly file size formatting

### DIFF
--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -17,6 +17,7 @@ import { downloadCidAsFile } from './utils/download.js'
 import { getShareLink } from './utils/get-share-link.js'
 import './file.css'
 import 'react-circular-progressbar/dist/styles.css'
+import { formatBytes } from '../../lib/size.js'
 
 export const File = ({ file, isDownload }: { file: FileState, isDownload?: boolean }): React.JSX.Element => {
   const { t } = useTranslation()
@@ -144,7 +145,7 @@ export const File = ({ file, isDownload }: { file: FileState, isDownload?: boole
           <FileIcon className="flex-shrink-0" name={name} error={error} />
         </div>
         <span className={fileNameClass}>{name}</span>
-        <span className={fileSizeClass}>{size != null ? `(~${size})` : ''}</span>
+        <span className={fileSizeClass}>{size != null ? `(~${formatBytes(size)})` : ''}</span>
       </div>
       <div className='flex items-center'>
         <span className='ml-auto'>{ renderFileStatus() }</span>

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -7,6 +7,7 @@ import { CircularProgressbar } from 'react-circular-progressbar'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { useTranslation } from 'react-i18next'
 import { useHelia } from '../../hooks/use-helia.js'
+import { formatBytes } from '../../lib/size.js'
 import IconDownload from '../../media/icons/download.svg'
 import IconView from '../../media/icons/view.svg'
 import { type FileState } from '../../providers/files-provider.jsx'
@@ -17,7 +18,6 @@ import { downloadCidAsFile } from './utils/download.js'
 import { getShareLink } from './utils/get-share-link.js'
 import './file.css'
 import 'react-circular-progressbar/dist/styles.css'
-import { formatBytes } from '../../lib/size.js'
 
 export const File = ({ file, isDownload }: { file: FileState, isDownload?: boolean }): React.JSX.Element => {
   const { t } = useTranslation()

--- a/src/lib/size.ts
+++ b/src/lib/size.ts
@@ -1,0 +1,11 @@
+export function formatBytes(bytes: number, decimals = 0): string {
+  if (!+bytes) return '0 Bytes' // checks if bytes is zero, NaN, or any falsy value
+
+  const k = 1024 // constant for the base of the exponentiation
+  const dm = decimals < 0 ? 0 : decimals // determines the number of decimal places to display
+  const sizes = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'] // array of size units
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k)) // calculates the appropriate size unit index
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}` // formats the size with the appropriate unit
+}

--- a/src/lib/size.ts
+++ b/src/lib/size.ts
@@ -1,5 +1,7 @@
-export function formatBytes(bytes: number, decimals = 0): string {
-  if (!+bytes) return '0 Bytes' // checks if bytes is zero, NaN, or any falsy value
+export function formatBytes (bytes: number, decimals = 0): string {
+  if (bytes === 0 || isNaN(bytes)) {
+    return '0 Bytes'
+  }
 
   const k = 1024 // constant for the base of the exponentiation
   const dm = decimals < 0 ? 0 : decimals // determines the number of decimal places to display


### PR DESCRIPTION
Before:

<img width="621" alt="Screenshot 2024-10-10 at 8 49 11 PM" src="https://github.com/user-attachments/assets/941f9038-2c40-43ba-ad06-06e8feac9100">


After:
<img width="590" alt="Screenshot 2024-10-10 at 8 49 28 PM" src="https://github.com/user-attachments/assets/dfd2b8da-b548-43c6-897a-80e16a74c1cd">

